### PR TITLE
Fix readthedocs python version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,6 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: "3.9"
+   version: "3.8"
    install:
    - requirements: docs/requirements_dev.txt


### PR DESCRIPTION
ReadTheDocs only support up to version `3.8`